### PR TITLE
Fix random build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ before_install:
   - adb shell input keyevent 82 &
   
 script:
-  - "/.gradlew clean build"
+  - "./gradlew clean build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,6 @@ before_install:
   - emulator -avd test -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+  
+script:
+  - "/.gradlew clean build"

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This repository contains only the code and resources for the Android portion of 
 
 The purpose of the project was to allow contractors to view pertinent job info and easily track their various hours from their phones. **[Click the thumbnails below]** for video of me demonstrating the prototype and the user guide PDFs.
 
-Prototype Demo Video:
+Prototype Demo (video player):
 ------
 
 <a href="http://brianboll.com/JobTracker%20Prototype.mp4"><img src="http://brianboll.com/images/videopreviewthumbnail.png" height="300" width="168" ></a>
 
 ---
 
-Admin and User Guide:
+Admin and User Guide (.pdf):
 -------
 
 <a href="docs/JobTracker Admin-User Guide.pdf"><img src="http://brianboll.com/images/userguidethumbnail.png" height="300" width="400" ></a>


### PR DESCRIPTION
Fixed a syntax error in the travis config file with executing gradle clean build. Hoping that running a clean build will clear up these inconsistent success/failures originating from emulator failing to install some dependencies that previously installed successfully.